### PR TITLE
✨ Add dynamic query for TodoCard retrieval using QueryDSL

### DIFF
--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/controller/TodoController.kt
@@ -13,6 +13,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 
 @RequestMapping("/api/v2/todos")
 @RestController
@@ -24,30 +26,25 @@ class TodoController(
         @RequestParam(required = false) keyword: String?,
         @RequestParam(required = false) category: Category?,
         @RequestParam(required = false) completed: Boolean?,
-        @RequestParam(defaultValue = "0") pageNumber: Int,
-        @RequestParam(defaultValue = "7") pageSize: Int
+        @RequestParam(required = false, defaultValue = "createdAt") sort: String,
+        @PageableDefault(size = 10) pageable: Pageable
     ): ResponseEntity<Page<TodoCardResponseWithComments>> {
-        val pageable = PageRequest.of(pageNumber, pageSize)
-        val result = todoService.findAllTodoCardsWithFilters(keyword, category, completed, pageable)
-        return ResponseEntity.ok(result)
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(todoService.findAllTodoCardsWithFilters(keyword, category, completed, sort, pageable))
     }
 
     @GetMapping("/{todoCardId}")
     fun getTodoCardById(
         @PathVariable todoCardId: Long,
     ): ResponseEntity<TodoCardResponseWithComments> {
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(todoService.getTodoCardById(todoCardId))
+        return ResponseEntity.status(HttpStatus.OK).body(todoService.getTodoCardById(todoCardId))
     }
 
     @PostMapping
     fun createTodoCard(
-        @AuthenticationPrincipal principal: UserPrincipal,
-        @RequestBody createTodoCardRequest: CreateTodoCardRequest
+        @AuthenticationPrincipal principal: UserPrincipal, @RequestBody createTodoCardRequest: CreateTodoCardRequest
     ): ResponseEntity<TodoCardResponse> {
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
+        return ResponseEntity.status(HttpStatus.CREATED)
             .body(todoService.createTodoCard(principal.id, createTodoCardRequest))
     }
 
@@ -57,19 +54,15 @@ class TodoController(
         @PathVariable todoCardId: Long,
         @RequestBody updateTodoCardRequest: UpdateTodoCardRequest
     ): ResponseEntity<TodoCardResponse> {
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
+        return ResponseEntity.status(HttpStatus.CREATED)
             .body(todoService.updateTodoCard(principal.id, todoCardId, updateTodoCardRequest))
     }
 
     @DeleteMapping("/{todoCardId}")
     fun deleteTodoCard(
-        @AuthenticationPrincipal principal: UserPrincipal,
-        @PathVariable todoCardId: Long
+        @AuthenticationPrincipal principal: UserPrincipal, @PathVariable todoCardId: Long
     ): ResponseEntity<Unit> {
         todoService.deleteTodoCard(principal.id, todoCardId)
-        return ResponseEntity
-            .status(HttpStatus.NO_CONTENT)
-            .build()
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 }

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/controller/TodoController.kt
@@ -5,24 +5,31 @@ import com.teamsparta.todosecurityproject.domain.todo.dto.CreateTodoCardRequest
 import com.teamsparta.todosecurityproject.domain.todo.dto.TodoCardResponse
 import com.teamsparta.todosecurityproject.domain.todo.dto.TodoCardResponseWithComments
 import com.teamsparta.todosecurityproject.domain.todo.dto.UpdateTodoCardRequest
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
 import com.teamsparta.todosecurityproject.infra.security.UserPrincipal
-import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 
 @RequestMapping("/api/v2/todos")
 @RestController
 class TodoController(
     private val todoService: TodoService
 ) {
-    @GetMapping
-    fun getAllTodoCards(
-    ): ResponseEntity<List<TodoCardResponseWithComments>> {
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(todoService.getAllTodoCards())
+    @GetMapping("/search")
+    fun findAllTodoCardsWithFilters(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(required = false) category: Category?,
+        @RequestParam(required = false) completed: Boolean?,
+        @RequestParam(defaultValue = "0") pageNumber: Int,
+        @RequestParam(defaultValue = "7") pageSize: Int
+    ): ResponseEntity<Page<TodoCardResponseWithComments>> {
+        val pageable = PageRequest.of(pageNumber, pageSize)
+        val result = todoService.findAllTodoCardsWithFilters(keyword, category, completed, pageable)
+        return ResponseEntity.ok(result)
     }
 
     @GetMapping("/{todoCardId}")

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/dto/TodoCardResponse.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/dto/TodoCardResponse.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.todosecurityproject.domain.todo.dto
 
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
 import com.teamsparta.todosecurityproject.domain.todo.model.TodoCard
 import com.teamsparta.todosecurityproject.domain.user.dto.UserResponse
 import java.time.ZonedDateTime
@@ -8,6 +9,8 @@ data class TodoCardResponse(
     val title: String,
     val description: String,
     val user: UserResponse,
+    val category: Category,
+    val completed: Boolean,
     val createdAt: ZonedDateTime?,
     val updatedAt: ZonedDateTime?,
 ) {
@@ -17,8 +20,10 @@ data class TodoCardResponse(
                 title = todoCard.title,
                 description = todoCard.description,
                 user = UserResponse.from(todoCard.user),
+                category = todoCard.category,
+                completed = todoCard.completed,
                 createdAt = todoCard.createdAt,
-                updatedAt = todoCard.updatedAt,
+                updatedAt = todoCard.updatedAt
             )
         }
     }

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/dto/TodoCardResponseWithComments.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/dto/TodoCardResponseWithComments.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.todosecurityproject.domain.todo.dto
 
 import com.teamsparta.todosecurityproject.domain.todo.comment.dto.CommentResponse
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
 import com.teamsparta.todosecurityproject.domain.todo.model.TodoCard
 import com.teamsparta.todosecurityproject.domain.user.dto.UserResponse
 import java.time.ZonedDateTime
@@ -10,6 +11,8 @@ data class TodoCardResponseWithComments(
     val title: String,
     val description: String,
     val user: UserResponse,
+    val category: Category,
+    val completed: Boolean,
     val createdAt: ZonedDateTime?,
     val updatedAt: ZonedDateTime?,
     val comments: List<CommentResponse>
@@ -20,6 +23,8 @@ data class TodoCardResponseWithComments(
                 title = todoCard.title,
                 description = todoCard.description,
                 user = UserResponse.from(todoCard.user),
+                category = todoCard.category,
+                completed = todoCard.completed,
                 createdAt = todoCard.createdAt,
                 updatedAt = todoCard.updatedAt,
                 comments = todoCard.comments.map { CommentResponse.from(it) }

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/repository/CustomTodoRepository.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/repository/CustomTodoRepository.kt
@@ -1,7 +1,12 @@
 package com.teamsparta.todosecurityproject.domain.todo.repository
 
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
 import com.teamsparta.todosecurityproject.domain.todo.model.TodoCard
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface CustomTodoRepository {
-    fun findAllWithComments(): List<TodoCard>
+    fun findAllWithFilters(
+        keyword: String?, category: Category?, completed: Boolean?, sort: String, pageable: Pageable
+    ): Page<TodoCard>
 }

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/repository/TodoRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/repository/TodoRepositoryImpl.kt
@@ -1,21 +1,43 @@
 package com.teamsparta.todosecurityproject.domain.todo.repository
 
-import com.teamsparta.todosecurityproject.domain.todo.comment.model.QComment
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.OrderSpecifier
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
 import com.teamsparta.todosecurityproject.domain.todo.model.QTodoCard
 import com.teamsparta.todosecurityproject.domain.todo.model.TodoCard
 import com.teamsparta.todosecurityproject.infra.querydsl.QueryDslSupport
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
-class TodoRepositoryImpl: CustomTodoRepository, QueryDslSupport() {
-    override fun findAllWithComments(): List<TodoCard> {
+class TodoRepositoryImpl : CustomTodoRepository, QueryDslSupport() {
+    override fun findAllWithFilters(
+        keyword: String?, category: Category?, completed: Boolean?, sort: String, pageable: Pageable
+    ): Page<TodoCard> {
         val todoCard = QTodoCard.todoCard
-        val comment = QComment.comment
 
-        return queryFactory
-            .selectFrom(todoCard)
-            .leftJoin(todoCard.comments, comment)
-            .fetchJoin()
-            .fetch()
+        val whereClause = BooleanBuilder()
+        keyword?.let {
+            whereClause.and(
+                todoCard.title.containsIgnoreCase(it).or(todoCard.description.containsIgnoreCase(it))
+            )
+        }
+        category?.let { whereClause.and(todoCard.category.eq(it)) }
+        completed?.let { whereClause.and(todoCard.completed.eq(it)) }
+
+        val totalCount = queryFactory.select(todoCard.count()).from(todoCard).where(whereClause).fetchOne() ?: 0L
+
+        val orderSpecifier = when (sort) {
+            "title" -> todoCard.title.asc()
+            "nickname" -> todoCard.user.nickname.asc()
+            else -> todoCard.createdAt.desc()
+        }
+
+        val query = queryFactory.selectFrom(todoCard).where(whereClause).offset(pageable.offset)
+            .limit(pageable.pageSize.toLong()).orderBy(orderSpecifier).fetch()
+
+        return PageImpl(query, pageable, totalCount)
     }
 }

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/service/TodoService.kt
@@ -16,18 +16,13 @@ import org.springframework.data.domain.Pageable
 
 @Service
 class TodoService(
-    val todoRepository: TodoRepository,
-    val commentRepository: CommentRepository,
-    val userRepository: UserRepository
+    val todoRepository: TodoRepository, val commentRepository: CommentRepository, val userRepository: UserRepository
 
 ) {
     fun findAllTodoCardsWithFilters(
-        keyword: String?,
-        category: Category?,
-        completed: Boolean?,
-        pageable: Pageable
+        keyword: String?, category: Category?, completed: Boolean?, sort: String, pageable: Pageable
     ): Page<TodoCardResponseWithComments> {
-        val todoCards = todoRepository.findAllWithFilters(keyword, category, completed, pageable)
+        val todoCards = todoRepository.findAllWithFilters(keyword, category, completed, sort, pageable)
         return todoCards.map { TodoCardResponseWithComments.from(it) }
     }
 

--- a/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/teamsparta/todosecurityproject/domain/todo/service/TodoService.kt
@@ -7,12 +7,12 @@ import com.teamsparta.todosecurityproject.domain.todo.dto.*
 import com.teamsparta.todosecurityproject.domain.user.repository.UserRepository
 import com.teamsparta.todosecurityproject.common.exception.ModelNotFoundException
 import com.teamsparta.todosecurityproject.common.exception.UnauthorizedException
-import com.teamsparta.todosecurityproject.domain.todo.comment.dto.CommentResponse
-import com.teamsparta.todosecurityproject.infra.security.UserPrincipal
+import com.teamsparta.todosecurityproject.domain.todo.model.Category
+import org.springframework.data.domain.Page
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.data.domain.Pageable
 
 @Service
 class TodoService(
@@ -20,9 +20,15 @@ class TodoService(
     val commentRepository: CommentRepository,
     val userRepository: UserRepository
 
-    ) {
-    fun getAllTodoCards(): List<TodoCardResponseWithComments> {
-        return todoRepository.findAllWithComments().map { TodoCardResponseWithComments.from(it) }
+) {
+    fun findAllTodoCardsWithFilters(
+        keyword: String?,
+        category: Category?,
+        completed: Boolean?,
+        pageable: Pageable
+    ): Page<TodoCardResponseWithComments> {
+        val todoCards = todoRepository.findAllWithFilters(keyword, category, completed, pageable)
+        return todoCards.map { TodoCardResponseWithComments.from(it) }
     }
 
     fun getTodoCardById(todoCardId: Long): TodoCardResponseWithComments {
@@ -46,7 +52,7 @@ class TodoService(
         val todoCard = findTodoCardById(todoCardId)
         checkUserAuthority(userId, todoCard)
         val (title, description, category, completed) = request
-        todoCard.updateTodoCard(title= title, description = description, category = category, completed = completed)
+        todoCard.updateTodoCard(title = title, description = description, category = category, completed = completed)
 
         return TodoCardResponse.from(todoRepository.save(todoCard))
     }


### PR DESCRIPTION
### 변경사항
- QueryDSL 활용 동적쿼리 작성
- Category Column 필터로 정렬할 수 있도록 설정
- 검색어 입력 시 제목이나 내용에 검색어가 포함되는 TodoCard 목록 조회 가능하도록 설정
- 할일 완료여부를 필터로 조회할 수 있도록 추가 설정
- Page Size = Default 10
- List -> Page 반환값 설정 변경
- 기본 정렬 기준 CreatedAt Desc으로 설정, Title이나 사용자의 Nickname을 기준으로 정렬 가능하도록 추가 설정